### PR TITLE
Update GetProductsRequestBuilder.php

### DIFF
--- a/src/Builders/GetProductsRequestBuilder.php
+++ b/src/Builders/GetProductsRequestBuilder.php
@@ -31,7 +31,7 @@ class GetProductsRequestBuilder extends AbstractRequestBuilder implements IReque
      */
     public function approved(bool $is): self
     {
-        $this->request->addData('approved', $is ? 'true' : 'false');
+        $this->request->addQueryParam('approved', $is ? 'true' : 'false');
 
         return $this;
     }
@@ -43,7 +43,7 @@ class GetProductsRequestBuilder extends AbstractRequestBuilder implements IReque
      */
     public function barcode(string $barcode): self
     {
-        $this->request->addData('barcode', $barcode);
+        $this->request->addQueryParam('barcode', $barcode);
 
         return $this;
     }
@@ -53,9 +53,9 @@ class GetProductsRequestBuilder extends AbstractRequestBuilder implements IReque
      *
      * @return $this
      */
-    public function startDate(int $timestamp): self
+    public function startDate(int $timestamp = null): self
     {
-        $this->request->addData('startDate', $timestamp);
+        $this->request->addQueryParam('startDate', $timestamp);
 
         return $this;
     }
@@ -65,9 +65,9 @@ class GetProductsRequestBuilder extends AbstractRequestBuilder implements IReque
      *
      * @return $this
      */
-    public function endDate(int $timestamp): self
+    public function endDate(int $timestamp = null): self
     {
-        $this->request->addData('endDate', $timestamp);
+        $this->request->addQueryParam('endDate', $timestamp);
 
         return $this;
     }
@@ -79,7 +79,7 @@ class GetProductsRequestBuilder extends AbstractRequestBuilder implements IReque
      */
     public function page(int $pageNumber): self
     {
-        $this->request->addData('page', $pageNumber);
+        $this->request->addQueryParam('page', $pageNumber);
 
         return $this;
     }
@@ -91,7 +91,7 @@ class GetProductsRequestBuilder extends AbstractRequestBuilder implements IReque
      */
     public function dataQueryType(DataQueryType $dataQueryType): self
     {
-        $this->request->addData('dataQueryType', (string) $dataQueryType);
+        $this->request->addQueryParam('dateQueryType', (string) $dataQueryType);
 
         return $this;
     }
@@ -103,7 +103,7 @@ class GetProductsRequestBuilder extends AbstractRequestBuilder implements IReque
      */
     public function size(int $size): self
     {
-        $this->request->addData('size', $size);
+        $this->request->addQueryParam('size', $size);
 
         return $this;
     }


### PR DESCRIPTION
Request final url sample before editing: "products?approved=$approved&barcode=$barcode&startDate=$startDate&endDate=$endDate&page=$page&dateQueryType=$dateQueryType&size=$size"
These variables are not data, they are query parameters. Please check other builders. 
And not "dataQueryType", its "dateQueryType". You may want to change the class names. 

After that request must like this:

    $results = Trendyol::create($user, $pass, $supplier_id)
            ->productService()
            ->gettingProducts()
            ->dataQueryType(TrDataQueryType::create(TrDataQueryType::CREATED_DATE))
            ->barcode('')
            ->startDate()
            ->endDate()
            ->page(0)
            ->size(50)
            ->approved(true)
            ->get();

Your tests were successful. I think you missed out on the results, the answer always brought up 20 results with page 0 on your test.

By the way, thank you for sharing this project. Regards.